### PR TITLE
Implement Night Mode Toggle & UI Improvements

### DIFF
--- a/opencodehub/accounts/templates/accounts/browse_projects.html
+++ b/opencodehub/accounts/templates/accounts/browse_projects.html
@@ -22,59 +22,6 @@
         background: #f5f5f7;
     }
 
-    /* Left Sidebar */
-    .left-sidebar {
-        width: 200px;
-        background: white;
-        border-right: 1px solid #e5e5e5;
-        padding: 20px 0;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .sidebar-section {
-        margin-bottom: 24px;
-    }
-
-    .sidebar-section-title {
-        font-size: 11px;
-        font-weight: 600;
-        color: #86868b;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        padding: 0 16px;
-        margin-bottom: 8px;
-    }
-
-    .sidebar-item {
-        padding: 10px 16px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        color: #1d1d1f;
-        text-decoration: none;
-        transition: all 0.2s;
-        cursor: pointer;
-        font-size: 14px;
-    }
-
-    .sidebar-item:hover {
-        background: #f5f5f7;
-        color: #667eea;
-    }
-
-    .sidebar-item.active {
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-        color: #667eea;
-        font-weight: 500;
-        border-left: 3px solid #667eea;
-    }
-
-    .sidebar-item i {
-        width: 20px;
-        font-size: 16px;
-    }
-
     /* Main Content */
     .main-content {
         flex: 1;
@@ -342,103 +289,64 @@
     }
 </style>
 
-<div class="dashboard-container">
-    <!-- Left Sidebar -->
-    <div class="left-sidebar">
-        <div class="create-btn" onclick="toggleCreateDropdown()">
-            <i class="fas fa-plus"></i>
-            Create
-            <div class="create-dropdown" id="createDropdown">
-                <a href="{% url 'create_project' %}" class="create-dropdown-item">New Project</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFileModal()">Upload File</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFolderModal()">Upload Folder</a>
-                <a href="{% url 'create_document' %}" class="create-dropdown-item">Document</a>
-            </div>
-        </div>
+<div class="content-header">
+    <h1><i class="fas fa-globe"></i> Browse Public Projects</h1>
+    <p>Discover and explore projects shared by the community</p>
+</div>
 
-        <div class="sidebar-section">
-            <div class="sidebar-section-title">Workspace</div>
-            <a href="{% url 'home' %}" class="sidebar-item">
-                <i class="fas fa-home"></i>
-                Home
-            </a>
-            <a href="{% url 'my_projects' %}" class="sidebar-item">
-                <i class="fas fa-briefcase"></i>
-                My work
-            </a>
-            <a href="{% url 'shared_with_me' %}" class="sidebar-item">
-                <i class="fas fa-users"></i>
-                Shared with me
-            </a>
-            <a href="{% url 'browse_projects' %}" class="sidebar-item active">
-                <i class="fas fa-globe"></i>
-                Browse
-            </a>
-        </div>
+<!-- Search Bar with Live Results -->
+<div class="search-container">
+    <div class="search-box">
+        <i class="fas fa-search"></i>
+        <input 
+            type="text" 
+            id="browseSearchInput"
+            placeholder="Search projects by title, description, or owner..." 
+            value="{{ search_query }}"
+            autocomplete="off"
+        >
+        <div id="browseSearchResults" class="search-results-dropdown"></div>
     </div>
+</div>
 
-    <!-- Main Content -->
-    <div class="main-content">
-        <div class="content-header">
-            <h1><i class="fas fa-globe"></i> Browse Public Projects</h1>
-            <p>Discover and explore projects shared by the community</p>
-        </div>
-
-        <!-- Search Bar with Live Results -->
-        <div class="search-container">
-            <div class="search-box">
-                <i class="fas fa-search"></i>
-                <input 
-                    type="text" 
-                    id="browseSearchInput"
-                    placeholder="Search projects by title, description, or owner..." 
-                    value="{{ search_query }}"
-                    autocomplete="off"
-                >
-                <div id="browseSearchResults" class="search-results-dropdown"></div>
-            </div>
-        </div>
-
-        <!-- Results Grid -->
-        <div id="resultsContainer">
-            {% if projects %}
-                <div class="projects-grid">
-                    {% for project in projects %}
-                    <div class="project-card" data-href="{% url 'project_detail' project.id %}">
-                        <div class="project-header">
-                            <div class="project-icon">
-                                <i class="fas fa-folder"></i>
-                            </div>
-                            <h3 class="project-title">{{ project.title }}</h3>
-                        </div>
-                        
-                        <p class="project-description">
-                            {{ project.description|default:"No description provided" }}
-                        </p>
-                        
-                        <div class="project-footer">
-                            <div class="project-owner">
-                                <div class="owner-avatar">
-                                    {{ project.owner.first_name.0|upper }}{{ project.owner.last_name.0|upper }}
-                                </div>
-                                <span>{{ project.owner.first_name }} {{ project.owner.last_name }}</span>
-                            </div>
-                            <div class="project-time">
-                                {{ project.updated_at|timesince }} ago
-                            </div>
-                        </div>
+<!-- Results Grid -->
+<div id="resultsContainer">
+    {% if projects %}
+        <div class="projects-grid">
+            {% for project in projects %}
+            <div class="project-card" data-href="{% url 'project_detail' project.id %}">
+                <div class="project-header">
+                    <div class="project-icon">
+                        <i class="fas fa-folder"></i>
                     </div>
-                    {% endfor %}
+                    <h3 class="project-title">{{ project.title }}</h3>
                 </div>
-            {% else %}
-                <div class="empty-state">
-                    <i class="fas fa-folder-open"></i>
-                    <h3>No projects found</h3>
-                    <p>{% if search_query %}No projects match your search.{% else %}There are no public projects yet.{% endif %}</p>
+                
+                <p class="project-description">
+                    {{ project.description|default:"No description provided" }}
+                </p>
+                
+                <div class="project-footer">
+                    <div class="project-owner">
+                        <div class="owner-avatar">
+                            {{ project.owner.first_name.0|upper }}{{ project.owner.last_name.0|upper }}
+                        </div>
+                        <span>{{ project.owner.first_name }} {{ project.owner.last_name }}</span>
+                    </div>
+                    <div class="project-time">
+                        {{ project.updated_at|timesince }} ago
+                    </div>
                 </div>
-            {% endif %}
+            </div>
+            {% endfor %}
         </div>
-    </div>
+    {% else %}
+        <div class="empty-state">
+            <i class="fas fa-folder-open"></i>
+            <h3>No projects found</h3>
+            <p>{% if search_query %}No projects match your search.{% else %}There are no public projects yet.{% endif %}</p>
+        </div>
+    {% endif %}
 </div>
 
 <script>

--- a/opencodehub/accounts/templates/accounts/home.html
+++ b/opencodehub/accounts/templates/accounts/home.html
@@ -209,6 +209,7 @@
     letter-spacing: 0.5px;
     background: linear-gradient(135deg, #1d1d1f 0%, var(--primary-blue) 100%);
     -webkit-background-clip: text;
+    background-clip: text;
     -webkit-text-fill-color: transparent;
 }
 
@@ -341,25 +342,24 @@
     font-size: 18px; 
     font-weight: 700;
     letter-spacing: 0.5px;
-    /* Apply Gradient Theme */
     background: linear-gradient(135deg, #1d1d1f 0%, var(--primary-blue) 100%);
     -webkit-background-clip: text;
+    background-clip: text;
     -webkit-text-fill-color: transparent;
     margin-bottom: 12px;
-    text-transform: none; /* Keep Title Case */
+    text-transform: none;
 }
 
 .project-selector {
     width: 100%;
-    padding: 12px 16px; /* Increased padding */
+    padding: 12px 16px;
     border: 1px solid #d1d5db; 
-    border-radius: 12px; /* More rounded */
+    border-radius: 12px;
     font-size: 14px;
     color: #1d1d1f;
-    background: rgba(255, 255, 255, 0.7); /* Light background for contrast */
+    background: rgba(255, 255, 255, 0.7);
     cursor: pointer;
     transition: all 0.2s;
-    /* Customizing the dropdown arrow */
     appearance: none; 
     background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 20 20'%3E%3Cpath fill='%236B7280' d='M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z'/%3E%3C/svg%3E");
     background-repeat: no-repeat;
@@ -407,6 +407,7 @@
     font-weight: 800;
     background: linear-gradient(45deg, var(--primary-blue), var(--accent-teal));
     -webkit-background-clip: text;
+    background-clip: text;
     -webkit-text-fill-color: transparent;
     line-height: 1;
 }
@@ -495,9 +496,6 @@
         <div class="stat-info">
             <div class="stat-label-compact">Total Projects</div>
             <div class="stat-value-compact">{{ total_projects_count }}</div>
-            <div class="stat-change">
-                <i class="fas fa-arrow-up"></i> +12%
-            </div>
         </div>
     </a>
     
@@ -508,9 +506,6 @@
         <div class="stat-info">
             <div class="stat-label-compact">Shared by You</div>
             <div class="stat-value-compact">{{ shared_by_me_count }}</div>
-            <div class="stat-change">
-                <i class="fas fa-arrow-up"></i> +8%
-            </div>
         </div>
     </a>
     
@@ -521,9 +516,6 @@
         <div class="stat-info">
             <div class="stat-label-compact">Shared with Me</div>
             <div class="stat-value-compact">{{ shared_with_me_count }}</div>
-            <div class="stat-change">
-                <i class="fas fa-arrow-up"></i> +15%
-            </div>
         </div>
     </a>
 </div>
@@ -594,9 +586,14 @@
                 </svg>
                 <div class="donut-center">
                     <div class="donut-center-value" id="totalContributions">0</div>
-                    <div class="donut-center-label">Total</div>
+                    <div class="donut-center-label">Uploads</div>
                 </div>
             </div>
+        </div>
+
+        <div class="chart-info" style="text-align: center; font-size: 12px; color: #6b7280; margin-bottom: 16px; padding: 8px 12px; background: rgba(59, 130, 246, 0.05); border-radius: 8px;">
+            <i class="fas fa-info-circle" style="color: #3b82f6;"></i>
+            Total file uploads by each team member in this project
         </div>
 
         <div class="contribution-legend" id="contributionLegend">
@@ -667,7 +664,7 @@
 
             <!-- Folder preview -->
             <div id="folderPreview" style="display: none; margin-bottom: 20px; padding: 16px; background: #f8f9fa; border-radius: 12px; max-height: 300px; overflow-y: auto;">
-                <div style="display: flex; justify-content: between align-items: center; margin-bottom: 12px;">
+                <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 12px;">
                     <strong style="font-size: 14px; color: #333;">
                         <i class="fas fa-folder-open"></i> Folder: <span id="folderName"></span>
                     </strong>

--- a/opencodehub/accounts/templates/accounts/home_base.html
+++ b/opencodehub/accounts/templates/accounts/home_base.html
@@ -61,6 +61,7 @@
         font-size: 24px;
         background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
         -webkit-background-clip: text;
+        background-clip: text;
         -webkit-text-fill-color: transparent;
     }
 
@@ -197,11 +198,19 @@
         flex: 1;
     }
 
-    .profile-name {
-        font-size: 14px;
+    .profile-dropdown .profile-name {
+        font-size: 14px !important;
         font-weight: 600;
-        color: #1d1d1f;
+        color: #1d1d1f !important;
         margin-bottom: 2px;
+        background: none !important;
+        -webkit-background-clip: unset !important;
+        background-clip: unset !important;
+        -webkit-text-fill-color: #1d1d1f !important;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        max-width: 160px;
     }
 
     .profile-email {
@@ -242,7 +251,7 @@
         margin-left: auto;
         width: 44px;
         height: 24px;
-        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+        background: #4b5563;
         border-radius: 12px;
         position: relative;
         cursor: pointer;
@@ -261,7 +270,7 @@
         background: white;
         border-radius: 50%;
         top: 2px;
-        right: 2px;
+        left: 2px;
         transition: all 0.2s;
         box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
     }
@@ -659,6 +668,7 @@
         font-size: 64px;
         background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
         -webkit-background-clip: text;
+        background-clip: text;
         -webkit-text-fill-color: transparent;
         opacity: 0.3;
         margin-bottom: 16px;
@@ -789,6 +799,161 @@
     .search-bar {
         position: relative;
     }
+
+    /* ========== DARK MODE STYLES ========== */
+    body.dark-mode {
+        background: #1a1a2e;
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .top-navbar {
+        background: linear-gradient(135deg, #1a1a2e 20%, #16213e 50%, #0f3460 100%);
+        border-bottom: 1px solid rgba(14, 165, 233, 0.2);
+    }
+
+    body.dark-mode .left-sidebar {
+        background: linear-gradient(180deg, #1a1a2e 0%, #16213e 100%);
+        border-right: 1px solid rgba(14, 165, 233, 0.15);
+    }
+
+    body.dark-mode .right-sidebar {
+        background: linear-gradient(135deg, #1a1a2e 10%, #16213e 50%, #0f3460 100%);
+    }
+
+    body.dark-mode .main-content {
+        background: #1a1a2e;
+    }
+
+    body.dark-mode .search-bar input {
+        background: rgba(255, 255, 255, 0.1);
+        border-color: rgba(14, 165, 233, 0.3);
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .search-bar input::placeholder {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .sidebar-section-title {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .sidebar-item {
+        color: #d1d5db;
+    }
+
+    body.dark-mode .sidebar-item:hover {
+        background: rgba(14, 165, 233, 0.15);
+        color: #0ea5e9;
+    }
+
+    body.dark-mode .create-btn {
+        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+    }
+
+    body.dark-mode .profile-dropdown {
+        background: rgba(26, 26, 46, 0.98);
+        border-color: rgba(14, 165, 233, 0.2);
+    }
+
+    body.dark-mode .profile-dropdown .profile-name {
+        color: #e4e4e7 !important;
+        -webkit-text-fill-color: #e4e4e7 !important;
+    }
+
+    body.dark-mode .dropdown-item {
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .profile-email {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .dropdown-item:hover {
+        background: rgba(14, 165, 233, 0.15);
+    }
+
+    body.dark-mode .dropdown-divider {
+        background: rgba(14, 165, 233, 0.2);
+    }
+
+    body.dark-mode .timeline-project {
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .timeline-description {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .projects-table {
+        background: rgba(26, 26, 46, 0.9);
+        border-color: rgba(14, 165, 233, 0.15);
+    }
+
+    body.dark-mode .table-header {
+        background: rgba(14, 165, 233, 0.1);
+        border-color: rgba(14, 165, 233, 0.2);
+    }
+
+    body.dark-mode .project-row {
+        border-color: rgba(14, 165, 233, 0.1);
+    }
+
+    body.dark-mode .project-row:hover {
+        background: rgba(14, 165, 233, 0.1);
+    }
+
+    body.dark-mode .project-name {
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .project-time,
+    body.dark-mode .project-type {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .empty-state h3 {
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .empty-state p {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .search-results {
+        background: rgba(26, 26, 46, 0.98);
+        border-color: rgba(14, 165, 233, 0.2);
+    }
+
+    body.dark-mode .search-result-item {
+        color: #e4e4e7;
+        border-color: rgba(14, 165, 233, 0.1);
+    }
+
+    body.dark-mode .search-result-item:hover {
+        background: rgba(14, 165, 233, 0.1);
+    }
+
+    body.dark-mode .search-result-title {
+        color: #e4e4e7;
+    }
+
+    body.dark-mode .search-result-meta {
+        color: #9ca3af;
+    }
+
+    body.dark-mode .search-no-results {
+        color: #9ca3af;
+    }
+
+    /* Toggle switch active state */
+    .toggle-switch.active {
+        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+    }
+
+    .toggle-switch.active::after {
+        left: 22px;
+    }
 </style>
     
     <!-- Extra CSS Block for child templates -->
@@ -844,14 +1009,14 @@
                         <i class="fas fa-user"></i>
                         My Profile
                     </a>
-                    <a href="#" class="dropdown-item">
+                    <a href="{% url 'settings' %}" class="dropdown-item">
                         <i class="fas fa-cog"></i>
                         Settings
                     </a>
-                    <div class="dropdown-item">
+                    <div class="dropdown-item" id="nightModeToggle" onclick="toggleNightMode(event)">
                         <i class="fas fa-moon"></i>
                         Night mode
-                        <div class="toggle-switch"></div>
+                        <div class="toggle-switch" id="nightModeSwitch"></div>
                     </div>
                     <div class="dropdown-divider"></div>
                     <a href="{% url 'logout' %}" class="dropdown-item">
@@ -892,6 +1057,10 @@
                     <i class="fas fa-user-friends"></i>
                     Shared with me
                 </a>
+                <a href="{% url 'shared_by_me' %}" class="sidebar-item">
+                    <i class="fas fa-share-alt"></i>
+                    Shared by me
+                </a>
                 <a href="{% url 'browse_projects' %}" class="sidebar-item">
                     <i class="fas fa-globe"></i>
                     Browse
@@ -900,18 +1069,13 @@
 
             <div class="sidebar-section">
                 <div class="sidebar-section-title">Personal</div>
-                <a href="#" class="sidebar-item">
-                    <i class="fas fa-comment-alt"></i>
-                    Messages
-                    <span class="badge">N</span>
+                <a href="{% url 'profile' %}" class="sidebar-item">
+                    <i class="fas fa-user"></i>
+                    Profile
                 </a>
-                <a href="#" class="sidebar-item">
-                    <i class="fas fa-bell"></i>
-                    Notifications
-                </a>
-                <a href="#" class="sidebar-item">
+                <a href="{% url 'settings' %}" class="sidebar-item">
                     <i class="fas fa-cog"></i>
-                    Setting
+                    Settings
                 </a>
                 <a href="{% url 'trash' %}" class="sidebar-item">
                     <i class="fas fa-trash"></i>
@@ -1092,6 +1256,51 @@
                 "'": '&#039;'
             };
             return text.replace(/[&<>"']/g, m => map[m]);
+        }
+
+        // ========== NIGHT MODE FUNCTIONALITY ==========
+        function toggleNightMode(event) {
+            event.stopPropagation();
+            const body = document.body;
+            const toggleSwitch = document.getElementById('nightModeSwitch');
+            const moonIcon = document.querySelector('#nightModeToggle i');
+            
+            body.classList.toggle('dark-mode');
+            toggleSwitch.classList.toggle('active');
+            
+            // Update icon
+            if (body.classList.contains('dark-mode')) {
+                moonIcon.classList.remove('fa-moon');
+                moonIcon.classList.add('fa-sun');
+                localStorage.setItem('nightMode', 'enabled');
+            } else {
+                moonIcon.classList.remove('fa-sun');
+                moonIcon.classList.add('fa-moon');
+                localStorage.setItem('nightMode', 'disabled');
+            }
+        }
+
+        // Initialize night mode on page load
+        function initNightMode() {
+            const nightMode = localStorage.getItem('nightMode');
+            const toggleSwitch = document.getElementById('nightModeSwitch');
+            const moonIcon = document.querySelector('#nightModeToggle i');
+            
+            if (nightMode === 'enabled') {
+                document.body.classList.add('dark-mode');
+                if (toggleSwitch) toggleSwitch.classList.add('active');
+                if (moonIcon) {
+                    moonIcon.classList.remove('fa-moon');
+                    moonIcon.classList.add('fa-sun');
+                }
+            }
+        }
+
+        // Run on page load
+        document.addEventListener('DOMContentLoaded', initNightMode);
+        // Also run immediately in case DOM is already loaded
+        if (document.readyState !== 'loading') {
+            initNightMode();
         }
     </script>
 </body>

--- a/opencodehub/accounts/templates/accounts/my_projects.html
+++ b/opencodehub/accounts/templates/accounts/my_projects.html
@@ -4,80 +4,6 @@
 
 {% block content %}
 <style>
-    body {
-        background: #f5f5f7 !important;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    }
-
-    .dashboard-container {
-        display: flex;
-        min-height: calc(100vh - 76px);
-        padding: 0;
-        margin: 0;
-        background: #f5f5f7;
-    }
-
-    /* Left Sidebar */
-    .left-sidebar {
-        width: 200px;
-        background: white;
-        border-right: 1px solid #e5e5e5;
-        padding: 20px 0;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .sidebar-section {
-        margin-bottom: 24px;
-    }
-
-    .sidebar-section-title {
-        font-size: 11px;
-        font-weight: 600;
-        color: #86868b;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        padding: 0 16px;
-        margin-bottom: 8px;
-    }
-
-    .sidebar-item {
-        padding: 10px 16px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        color: #1d1d1f;
-        text-decoration: none;
-        transition: all 0.2s;
-        cursor: pointer;
-        font-size: 14px;
-    }
-
-    .sidebar-item:hover {
-        background: #f5f5f7;
-        color: #667eea;
-    }
-
-    .sidebar-item.active {
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-        color: #667eea;
-        font-weight: 500;
-        border-left: 3px solid #667eea;
-    }
-
-    .sidebar-item i {
-        width: 20px;
-        font-size: 16px;
-    }
-
-    /* Main Content */
-    .main-content {
-        flex: 1;
-        overflow-y: auto;
-        padding: 32px 40px;
-        background: #f5f5f7;
-    }
-
     .content-header {
         margin-bottom: 32px;
     }
@@ -289,118 +215,79 @@
     }
 </style>
 
-<div class="dashboard-container">
-    <!-- Left Sidebar -->
-    <div class="left-sidebar">
-        <div class="create-btn" onclick="toggleCreateDropdown()">
-            <i class="fas fa-plus"></i>
-            Create
-            <div class="create-dropdown" id="createDropdown">
-                <a href="{% url 'create_project' %}" class="create-dropdown-item">New Project</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFileModal()">Upload File</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFolderModal()">Upload Folder</a>
-                <a href="{% url 'create_document' %}" class="create-dropdown-item">Document</a>
-            </div>
-        </div>
+<div class="content-header">
+    <h1><i class="fas fa-briefcase"></i> My Projects</h1>
+    <p>Manage and explore your created projects</p>
+</div>
 
-        <div class="sidebar-section">
-            <div class="sidebar-section-title">Workspace</div>
-            <a href="{% url 'home' %}" class="sidebar-item">
-                <i class="fas fa-home"></i>
-                Home
-            </a>
-            <a href="{% url 'my_projects' %}" class="sidebar-item active">
-                <i class="fas fa-briefcase"></i>
-                My work
-            </a>
-            <a href="{% url 'shared_with_me' %}" class="sidebar-item">
-                <i class="fas fa-users"></i>
-                Shared with me
-            </a>
-            <a href="{% url 'browse_projects' %}" class="sidebar-item">
-                <i class="fas fa-globe"></i>
-                Browse
-            </a>
-        </div>
-    </div>
-
-    <!-- Main Content -->
-    <div class="main-content">
-        <div class="content-header">
-            <h1><i class="fas fa-briefcase"></i> My Projects</h1>
-            <p>Manage and explore your created projects</p>
-        </div>
-
-        {% if projects %}
-            <div class="projects-grid">
-                {% for project in projects %}
-                <a href="{% url 'project_detail' project.id %}" class="project-card-link">
-                    <div class="project-card">
-                        <div class="project-header">
-                            <div class="project-icon">
-                                <i class="fas fa-folder"></i>
-                            </div>
-                            <h3 class="project-title">{{ project.title }}</h3>
-                            <div class="project-badges">
-                                {% if project.is_public %}
-                                    <span class="project-badge badge-public">
-                                        <i class="fas fa-globe"></i>
-                                    </span>
-                                {% else %}
-                                    <span class="project-badge badge-private">
-                                        <i class="fas fa-lock"></i>
-                                    </span>
-                                {% endif %}
-                                
-                                {% if project.shared_with.all.count > 0 %}
-                                    <span class="project-badge badge-shared">
-                                        <i class="fas fa-users"></i> {{ project.shared_with.all.count }}
-                                    </span>
-                                {% endif %}
-                            </div>
-                        </div>
-                        
-                        <p class="project-description">
-                            {{ project.description|default:"No description provided" }}
-                        </p>
-                        
-                        {% if project.shared_with.all %}
-                        <div class="shared-users">
-                            <span class="shared-label">SHARED WITH:</span>
-                            <div class="user-avatars">
-                                {% for shared_user in project.shared_with.all|slice:":3" %}
-                                    <div class="mini-avatar" title="{{ shared_user.username }}">
-                                        {{ shared_user.first_name.0|upper }}{{ shared_user.last_name.0|upper }}
-                                    </div>
-                                {% endfor %}
-                                {% if project.shared_with.all.count > 3 %}
-                                    <div class="mini-avatar" style="background: #86868b;">
-                                        +{{ project.shared_with.all.count|add:"-3" }}
-                                    </div>
-                                {% endif %}
-                            </div>
-                        </div>
+{% if projects %}
+    <div class="projects-grid">
+        {% for project in projects %}
+        <a href="{% url 'project_detail' project.id %}" class="project-card-link">
+            <div class="project-card">
+                <div class="project-header">
+                    <div class="project-icon">
+                        <i class="fas fa-folder"></i>
+                    </div>
+                    <h3 class="project-title">{{ project.title }}</h3>
+                    <div class="project-badges">
+                        {% if project.is_public %}
+                            <span class="project-badge badge-public">
+                                <i class="fas fa-globe"></i>
+                            </span>
+                        {% else %}
+                            <span class="project-badge badge-private">
+                                <i class="fas fa-lock"></i>
+                            </span>
                         {% endif %}
                         
-                        <div class="project-footer">
-                            <div class="project-time">
-                                <i class="fas fa-clock"></i> {{ project.updated_at|timesince }} ago
-                            </div>
-                            <span class="view-btn">
-                                <i class="fas fa-eye"></i> View
+                        {% if project.shared_with.all.count > 0 %}
+                            <span class="project-badge badge-shared">
+                                <i class="fas fa-users"></i> {{ project.shared_with.all.count }}
                             </span>
-                        </div>
+                        {% endif %}
                     </div>
-                </a>
-                {% endfor %}
+                </div>
+                
+                <p class="project-description">
+                    {{ project.description|default:"No description provided" }}
+                </p>
+                
+                {% if project.shared_with.all %}
+                <div class="shared-users">
+                    <span class="shared-label">SHARED WITH:</span>
+                    <div class="user-avatars">
+                        {% for shared_user in project.shared_with.all|slice:":3" %}
+                            <div class="mini-avatar" title="{{ shared_user.username }}">
+                                {{ shared_user.first_name.0|upper }}{{ shared_user.last_name.0|upper }}
+                            </div>
+                        {% endfor %}
+                        {% if project.shared_with.all.count > 3 %}
+                            <div class="mini-avatar" style="background: #86868b;">
+                                +{{ project.shared_with.all.count|add:"-3" }}
+                            </div>
+                        {% endif %}
+                    </div>
+                </div>
+                {% endif %}
+                
+                <div class="project-footer">
+                    <div class="project-time">
+                        <i class="fas fa-clock"></i> {{ project.updated_at|timesince }} ago
+                    </div>
+                    <span class="view-btn">
+                        <i class="fas fa-eye"></i> View
+                    </span>
+                </div>
             </div>
-        {% else %}
-            <div class="empty-state">
-                <i class="fas fa-folder-open"></i>
-                <h3>No projects yet</h3>
-                <p>You haven't created any projects yet. Create your first project to get started!</p>
-            </div>
-        {% endif %}
+        </a>
+        {% endfor %}
     </div>
-</div>
+{% else %}
+    <div class="empty-state">
+        <i class="fas fa-folder-open"></i>
+        <h3>No projects yet</h3>
+        <p>You haven't created any projects yet. Create your first project to get started!</p>
+    </div>
+{% endif %}
 {% endblock %}

--- a/opencodehub/accounts/templates/accounts/settings.html
+++ b/opencodehub/accounts/templates/accounts/settings.html
@@ -1,0 +1,329 @@
+{% extends 'accounts/home_base.html' %}
+
+{% block title %}Settings - OpenCodeHub{% endblock %}
+
+{% block content %}
+<style>
+    .settings-container {
+        max-width: 800px;
+        margin: 0 auto;
+    }
+
+    .content-header {
+        margin-bottom: 32px;
+    }
+
+    .content-header h1 {
+        font-size: 32px;
+        font-weight: 700;
+        color: #1d1d1f;
+        margin: 0 0 8px 0;
+        display: flex;
+        align-items: center;
+        gap: 12px;
+    }
+
+    .content-header h1 i {
+        color: #0ea5e9;
+    }
+
+    .content-header p {
+        color: #86868b;
+        font-size: 14px;
+        margin: 0;
+    }
+
+    .settings-section {
+        background: white;
+        border-radius: 16px;
+        padding: 24px;
+        margin-bottom: 24px;
+        border: 1px solid rgba(14, 165, 233, 0.1);
+        box-shadow: 0 4px 20px rgba(14, 165, 233, 0.08);
+    }
+
+    .settings-section-title {
+        font-size: 18px;
+        font-weight: 600;
+        color: #1d1d1f;
+        margin-bottom: 20px;
+        padding-bottom: 12px;
+        border-bottom: 1px solid #f0f0f0;
+        display: flex;
+        align-items: center;
+        gap: 10px;
+    }
+
+    .settings-section-title i {
+        color: #0ea5e9;
+    }
+
+    .settings-item {
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+        padding: 16px 0;
+        border-bottom: 1px solid #f0f0f0;
+    }
+
+    .settings-item:last-child {
+        border-bottom: none;
+    }
+
+    .settings-item-info {
+        flex: 1;
+    }
+
+    .settings-item-label {
+        font-size: 14px;
+        font-weight: 500;
+        color: #1d1d1f;
+        margin-bottom: 4px;
+    }
+
+    .settings-item-description {
+        font-size: 12px;
+        color: #86868b;
+    }
+
+    .toggle-switch {
+        width: 48px;
+        height: 26px;
+        background: #e5e5e5;
+        border-radius: 13px;
+        position: relative;
+        cursor: pointer;
+        transition: all 0.3s ease;
+    }
+
+    .toggle-switch.active {
+        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+    }
+
+    .toggle-switch::after {
+        content: '';
+        position: absolute;
+        width: 22px;
+        height: 22px;
+        background: white;
+        border-radius: 50%;
+        top: 2px;
+        left: 2px;
+        transition: all 0.3s ease;
+        box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+    }
+
+    .toggle-switch.active::after {
+        left: 24px;
+    }
+
+    .coming-soon-badge {
+        background: linear-gradient(135deg, #f59e0b 0%, #f97316 100%);
+        color: white;
+        font-size: 10px;
+        font-weight: 600;
+        padding: 4px 8px;
+        border-radius: 4px;
+        text-transform: uppercase;
+    }
+
+    .settings-btn {
+        padding: 10px 20px;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: all 0.2s;
+        border: none;
+    }
+
+    .settings-btn-primary {
+        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+        color: white;
+    }
+
+    .settings-btn-primary:hover {
+        transform: translateY(-2px);
+        box-shadow: 0 4px 12px rgba(14, 165, 233, 0.3);
+    }
+
+    .settings-btn-danger {
+        background: #fee2e2;
+        color: #dc2626;
+    }
+
+    .settings-btn-danger:hover {
+        background: #fecaca;
+    }
+
+    .user-info-card {
+        display: flex;
+        align-items: center;
+        gap: 16px;
+        padding: 20px;
+        background: linear-gradient(135deg, #e0f2fe 0%, #ecfeff 100%);
+        border-radius: 12px;
+        margin-bottom: 20px;
+    }
+
+    .user-info-avatar {
+        width: 64px;
+        height: 64px;
+        border-radius: 50%;
+        background: linear-gradient(135deg, #0ea5e9 0%, #06b6d4 100%);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        color: white;
+        font-size: 24px;
+        font-weight: 600;
+        overflow: hidden;
+    }
+
+    .user-info-avatar img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+    }
+
+    .user-info-details h3 {
+        font-size: 18px;
+        font-weight: 600;
+        color: #1d1d1f;
+        margin: 0 0 4px 0;
+    }
+
+    .user-info-details p {
+        font-size: 14px;
+        color: #86868b;
+        margin: 0;
+    }
+</style>
+
+<div class="settings-container">
+    <div class="content-header">
+        <h1><i class="fas fa-cog"></i> Settings</h1>
+        <p>Manage your account settings and preferences</p>
+    </div>
+
+    <!-- Account Section -->
+    <div class="settings-section">
+        <div class="settings-section-title">
+            <i class="fas fa-user-circle"></i>
+            Account
+        </div>
+        
+        <div class="user-info-card">
+            <div class="user-info-avatar">
+                {% if user.profile_picture %}
+                    <img src="{{ user.profile_picture.url }}" alt="{{ user.username }}">
+                {% else %}
+                    {{ user.first_name.0|upper }}{{ user.last_name.0|upper }}
+                {% endif %}
+            </div>
+            <div class="user-info-details">
+                <h3>{{ user.first_name }} {{ user.last_name }}</h3>
+                <p>{{ user.email }}</p>
+            </div>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Edit Profile</div>
+                <div class="settings-item-description">Update your name, bio, and profile picture</div>
+            </div>
+            <a href="{% url 'profile' %}" class="settings-btn settings-btn-primary">
+                <i class="fas fa-edit"></i> Edit
+            </a>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Change Password</div>
+                <div class="settings-item-description">Update your account password</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Two-Factor Authentication</div>
+                <div class="settings-item-description">Add an extra layer of security to your account</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+    </div>
+
+    <!-- Preferences Section -->
+    <div class="settings-section">
+        <div class="settings-section-title">
+            <i class="fas fa-sliders-h"></i>
+            Preferences
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Dark Mode</div>
+                <div class="settings-item-description">Switch between light and dark theme</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Email Notifications</div>
+                <div class="settings-item-description">Receive email updates about your projects</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Language</div>
+                <div class="settings-item-description">Choose your preferred language</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+    </div>
+
+    <!-- Privacy Section -->
+    <div class="settings-section">
+        <div class="settings-section-title">
+            <i class="fas fa-shield-alt"></i>
+            Privacy & Security
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Profile Visibility</div>
+                <div class="settings-item-description">Control who can see your profile</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Activity Status</div>
+                <div class="settings-item-description">Show when you're active on OpenCodeHub</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+    </div>
+
+    <!-- Danger Zone -->
+    <div class="settings-section" style="border-color: #fecaca;">
+        <div class="settings-section-title" style="color: #dc2626;">
+            <i class="fas fa-exclamation-triangle"></i>
+            Danger Zone
+        </div>
+
+        <div class="settings-item">
+            <div class="settings-item-info">
+                <div class="settings-item-label">Delete Account</div>
+                <div class="settings-item-description">Permanently delete your account and all data</div>
+            </div>
+            <span class="coming-soon-badge">Coming Soon</span>
+        </div>
+    </div>
+</div>
+{% endblock %}

--- a/opencodehub/accounts/templates/accounts/shared_by_me.html
+++ b/opencodehub/accounts/templates/accounts/shared_by_me.html
@@ -4,80 +4,6 @@
 
 {% block content %}
 <style>
-    body {
-        background: #f5f5f7 !important;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    }
-
-    .dashboard-container {
-        display: flex;
-        min-height: calc(100vh - 76px);
-        padding: 0;
-        margin: 0;
-        background: #f5f5f7;
-    }
-
-    /* Left Sidebar */
-    .left-sidebar {
-        width: 200px;
-        background: white;
-        border-right: 1px solid #e5e5e5;
-        padding: 20px 0;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .sidebar-section {
-        margin-bottom: 24px;
-    }
-
-    .sidebar-section-title {
-        font-size: 11px;
-        font-weight: 600;
-        color: #86868b;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        padding: 0 16px;
-        margin-bottom: 8px;
-    }
-
-    .sidebar-item {
-        padding: 10px 16px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        color: #1d1d1f;
-        text-decoration: none;
-        transition: all 0.2s;
-        cursor: pointer;
-        font-size: 14px;
-    }
-
-    .sidebar-item:hover {
-        background: #f5f5f7;
-        color: #667eea;
-    }
-
-    .sidebar-item.active {
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-        color: #667eea;
-        font-weight: 500;
-        border-left: 3px solid #667eea;
-    }
-
-    .sidebar-item i {
-        width: 20px;
-        font-size: 16px;
-    }
-
-    /* Main Content */
-    .main-content {
-        flex: 1;
-        overflow-y: auto;
-        padding: 32px 40px;
-        background: #f5f5f7;
-    }
-
     .content-header {
         margin-bottom: 32px;
     }
@@ -93,6 +19,20 @@
         color: #86868b;
         font-size: 14px;
         margin: 0;
+    }
+
+    .back-btn {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: #667eea;
+        text-decoration: none;
+        font-size: 14px;
+        margin-bottom: 16px;
+    }
+
+    .back-btn:hover {
+        text-decoration: underline;
     }
 
     /* Projects Table */
@@ -423,56 +363,19 @@
     }
 </style>
 
-<div class="dashboard-container">
-    <!-- Left Sidebar -->
-    <div class="left-sidebar">
-        <div class="create-btn" onclick="toggleCreateDropdown()">
-            <i class="fas fa-plus"></i>
-            Create
-            <div class="create-dropdown" id="createDropdown">
-                <a href="{% url 'create_project' %}" class="create-dropdown-item">New Project</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFileModal()">Upload File</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFolderModal()">Upload Folder</a>
-                <a href="{% url 'create_document' %}" class="create-dropdown-item">Document</a>
-            </div>
-        </div>
+<a href="{% url 'home' %}" class="back-btn">
+    <i class="fas fa-arrow-left"></i> Back to Home
+</a>
 
-        <div class="sidebar-section">
-            <div class="sidebar-section-title">Workspace</div>
-            <a href="{% url 'home' %}" class="sidebar-item">
-                <i class="fas fa-home"></i>
-                Home
-            </a>
-            <a href="{% url 'my_projects' %}" class="sidebar-item">
-                <i class="fas fa-briefcase"></i>
-                My work
-            </a>
-            <a href="{% url 'shared_with_me' %}" class="sidebar-item">
-                <i class="fas fa-users"></i>
-                Shared with me
-            </a>
-            <a href="{% url 'browse_projects' %}" class="sidebar-item">
-                <i class="fas fa-globe"></i>
-                Browse
-            </a>
-        </div>
-    </div>
+<div class="content-header">
+    <h1><i class="fas fa-share-alt"></i> Shared By Me</h1>
+    <p>Projects you've shared with others ({{ total_count }} project{{ total_count|pluralize }})</p>
+</div>
 
-    <!-- Main Content -->
-    <div class="main-content">
-        <a href="{% url 'home' %}" class="back-btn">
-            <i class="fas fa-arrow-left"></i> Back to Home
-        </a>
-        
-        <div class="content-header">
-            <h1><i class="fas fa-share-alt"></i> Shared By Me</h1>
-            <p>Projects you've shared with others ({{ total_count }} project{{ total_count|pluralize }})</p>
-        </div>
-
-        {% if projects %}
-        <div class="content-layout">
-            <!-- Projects Table -->
-            <div class="projects-table">
+{% if projects %}
+<div class="content-layout">
+    <!-- Projects Table -->
+    <div class="projects-table">
                 <div class="table-header">
                     <div></div>
                     <div>PROJECT NAME</div>
@@ -555,17 +458,15 @@
                 </div>
             </div>
         </div>
-        {% else %}
-        <div class="projects-table">
-            <div class="empty-state">
-                <i class="fas fa-share-alt"></i>
-                <h3>No shared projects</h3>
-                <p>You haven't shared any projects with others yet. Share a project to collaborate!</p>
-            </div>
-        </div>
-        {% endif %}
+{% else %}
+<div class="projects-table">
+    <div class="empty-state">
+        <i class="fas fa-share-alt"></i>
+        <h3>No shared projects</h3>
+        <p>You haven't shared any projects with others yet. Share a project to collaborate!</p>
     </div>
 </div>
+{% endif %}
 
 <script>
 document.querySelectorAll('.project-row').forEach(row => {

--- a/opencodehub/accounts/templates/accounts/shared_with_me.html
+++ b/opencodehub/accounts/templates/accounts/shared_with_me.html
@@ -4,80 +4,6 @@
 
 {% block content %}
 <style>
-    body {
-        background: #f5f5f7 !important;
-        font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-    }
-
-    .dashboard-container {
-        display: flex;
-        min-height: calc(100vh - 76px);
-        padding: 0;
-        margin: 0;
-        background: #f5f5f7;
-    }
-
-    /* Left Sidebar */
-    .left-sidebar {
-        width: 200px;
-        background: white;
-        border-right: 1px solid #e5e5e5;
-        padding: 20px 0;
-        display: flex;
-        flex-direction: column;
-    }
-
-    .sidebar-section {
-        margin-bottom: 24px;
-    }
-
-    .sidebar-section-title {
-        font-size: 11px;
-        font-weight: 600;
-        color: #86868b;
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        padding: 0 16px;
-        margin-bottom: 8px;
-    }
-
-    .sidebar-item {
-        padding: 10px 16px;
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        color: #1d1d1f;
-        text-decoration: none;
-        transition: all 0.2s;
-        cursor: pointer;
-        font-size: 14px;
-    }
-
-    .sidebar-item:hover {
-        background: #f5f5f7;
-        color: #667eea;
-    }
-
-    .sidebar-item.active {
-        background: linear-gradient(135deg, rgba(102, 126, 234, 0.1) 0%, rgba(118, 75, 162, 0.1) 100%);
-        color: #667eea;
-        font-weight: 500;
-        border-left: 3px solid #667eea;
-    }
-
-    .sidebar-item i {
-        width: 20px;
-        font-size: 16px;
-    }
-
-    /* Main Content */
-    .main-content {
-        flex: 1;
-        overflow-y: auto;
-        padding: 32px 40px;
-        background: #f5f5f7;
-    }
-
     .content-header {
         margin-bottom: 32px;
     }
@@ -224,104 +150,65 @@
     }
 </style>
 
-<div class="dashboard-container">
-    <!-- Left Sidebar -->
-    <div class="left-sidebar">
-        <div class="create-btn" onclick="toggleCreateDropdown()">
-            <i class="fas fa-plus"></i>
-            Create
-            <div class="create-dropdown" id="createDropdown">
-                <a href="{% url 'create_project' %}" class="create-dropdown-item">New Project</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFileModal()">Upload File</a>
-                <a href="#" class="create-dropdown-item" onclick="event.preventDefault(); openUploadFolderModal()">Upload Folder</a>
-                <a href="{% url 'create_document' %}" class="create-dropdown-item">Document</a>
-            </div>
-        </div>
-
-        <div class="sidebar-section">
-            <div class="sidebar-section-title">Workspace</div>
-            <a href="{% url 'home' %}" class="sidebar-item">
-                <i class="fas fa-home"></i>
-                Home
-            </a>
-            <a href="{% url 'my_projects' %}" class="sidebar-item">
-                <i class="fas fa-briefcase"></i>
-                My work
-            </a>
-            <a href="{% url 'shared_with_me' %}" class="sidebar-item active">
-                <i class="fas fa-users"></i>
-                Shared with me
-            </a>
-            <a href="{% url 'browse_projects' %}" class="sidebar-item">
-                <i class="fas fa-globe"></i>
-                Browse
-            </a>
-        </div>
-    </div>
-
-    <!-- Main Content -->
-    <div class="main-content">
-        <div class="content-header">
-            <h1><i class="fas fa-users"></i> Shared With Me</h1>
-            <p>Projects that others have shared with you</p>
-        </div>
-
-        {% if projects %}
-        <div class="projects-table">
-            <div class="table-header">
-                <div></div>
-                <div>NAME</div>
-                <div>SHARED BY</div>
-                <div>LAST MODIFIED</div>
-                <div>ACCESS</div>
-                <div></div>
-            </div>
-
-            {% for project in projects %}
-            <div class="project-row" data-href="{% url 'project_detail' project.id %}">
-                <div class="project-icon">
-                    <i class="fas fa-users"></i>
-                </div>
-                <div class="project-name">
-                    {{ project.title }}
-                </div>
-                <div class="project-owner">
-                    <div class="owner-avatar">
-                        {{ project.owner.first_name.0|upper }}{{ project.owner.last_name.0|upper }}
-                    </div>
-                    <span>{{ project.owner.first_name }} {{ project.owner.last_name }}</span>
-                </div>
-                <div class="project-time">{{ project.updated_at|timesince }} ago</div>
-                <div>
-                    {% if project.permission == 'edit' %}
-                    <span class="project-badge" style="background: #d4edda; color: #155724;">
-                        <i class="fas fa-edit"></i>
-                        Can Edit
-                    </span>
-                    {% else %}
-                    <span class="project-badge" style="background: #d1ecf1; color: #0c5460;">
-                        <i class="fas fa-eye"></i>
-                        View Only
-                    </span>
-                    {% endif %}
-                </div>
-                <div class="project-menu">
-                    <i class="fas fa-ellipsis-v"></i>
-                </div>
-            </div>
-            {% endfor %}
-        </div>
-        {% else %}
-        <div class="projects-table">
-            <div class="empty-state">
-                <i class="fas fa-users"></i>
-                <h3>No shared projects</h3>
-                <p>When someone shares a project with you, it will appear here</p>
-            </div>
-        </div>
-        {% endif %}
-    </div>
+<div class="content-header">
+    <h1><i class="fas fa-users"></i> Shared With Me</h1>
+    <p>Projects that others have shared with you</p>
 </div>
+
+{% if projects %}
+    <div class="projects-table">
+        <div class="table-header">
+            <div></div>
+            <div>NAME</div>
+            <div>SHARED BY</div>
+            <div>LAST MODIFIED</div>
+            <div>ACCESS</div>
+            <div></div>
+        </div>
+
+        {% for project in projects %}
+        <div class="project-row" data-href="{% url 'project_detail' project.id %}">
+            <div class="project-icon">
+                <i class="fas fa-users"></i>
+            </div>
+            <div class="project-name">
+                {{ project.title }}
+            </div>
+            <div class="project-owner">
+                <div class="owner-avatar">
+                    {{ project.owner.first_name.0|upper }}{{ project.owner.last_name.0|upper }}
+                </div>
+                <span>{{ project.owner.first_name }} {{ project.owner.last_name }}</span>
+            </div>
+            <div class="project-time">{{ project.updated_at|timesince }} ago</div>
+            <div>
+                {% if project.permission == 'edit' %}
+                <span class="project-badge" style="background: #d4edda; color: #155724;">
+                    <i class="fas fa-edit"></i>
+                    Can Edit
+                </span>
+                {% else %}
+                <span class="project-badge" style="background: #d1ecf1; color: #0c5460;">
+                    <i class="fas fa-eye"></i>
+                    View Only
+                </span>
+                {% endif %}
+            </div>
+            <div class="project-menu">
+                <i class="fas fa-ellipsis-v"></i>
+            </div>
+        </div>
+        {% endfor %}
+    </div>
+{% else %}
+    <div class="projects-table">
+        <div class="empty-state">
+            <i class="fas fa-users"></i>
+            <h3>No shared projects</h3>
+            <p>When someone shares a project with you, it will appear here</p>
+        </div>
+    </div>
+{% endif %}
 
 <script>
 document.querySelectorAll('.project-row').forEach(row => {

--- a/opencodehub/accounts/urls.py
+++ b/opencodehub/accounts/urls.py
@@ -67,6 +67,9 @@ urlpatterns = [
     path('profile/', views.profile, name='profile'),
     path('profile/update/', views.update_profile, name='update_profile'),
     path('profile/<str:username>/', views.profile, name='user_profile'),
+    
+    # Settings
+    path('settings/', views.settings_view, name='settings'),
 
     #
     path('api/search/', views.search_projects, name='search_projects'),

--- a/opencodehub/accounts/views.py
+++ b/opencodehub/accounts/views.py
@@ -1692,6 +1692,17 @@ def update_profile(request):
     
     return redirect('profile')
 
+
+# SETTINGS PAGE
+@login_required
+def settings_view(request):
+    """User settings page"""
+    context = {
+        'user': request.user,
+    }
+    return render(request, 'accounts/settings.html', context)
+
+
 @login_required
 @require_GET
 def search_projects(request):


### PR DESCRIPTION
## Summary
This PR implements a fully functional night mode feature and includes several UI improvements.

---

## Night Mode Feature
- **Toggle Switch**: Added in profile dropdown menu (click avatar → Night mode)
- **Persistence**: User preference saved in localStorage, persists across sessions
- **Coverage**: Dark mode styling for navbar, sidebars, main content, dropdowns, tables, search results
- **Visual Feedback**: Toggle OFF (gray) = Light Mode, Toggle ON (cyan) = Dark Mode
- **Icon Update**: Moon icon changes to sun when dark mode is active

---

## Sidebar Navigation Updates
- Added **'Shared by me'** link to Working Space section
- Updated **Personal section**: Now shows Profile, Settings, Trash
- Removed Messages and Notifications (not implemented)
- Fixed Settings link to navigate to actual settings page

---

## New Settings Page
- Created `settings.html` template
- Added URL route `/settings/` and view function

---

## Template Cleanup
- Removed duplicate sidebar CSS from child templates
- Fixed HTML structure issues in multiple templates

---

## Home Page Improvements
- Removed placeholder percentage indicators from stat cards
- Changed donut chart label from 'Total' to 'Uploads' for clarity

---

## Files Changed (9 files, +785 -653 lines)
- [home_base.html](cci:7://file:///d:/OPENCODEHUB-APP/opencodehub/accounts/templates/accounts/home_base.html:0:0-0:0) - Night mode CSS, toggle JS, sidebar updates
- `home.html` - Stat card and chart label fixes
- `settings.html` - New settings page template
- [urls.py](cci:7://file:///d:/OPENCODEHUB-APP/opencodehub/opencodehub/urls.py:0:0-0:0) - Added settings route
- `views.py` - Added settings view
- `my_projects.html`, `shared_with_me.html`, `shared_by_me.html`, `browse_projects.html` - Template cleanup